### PR TITLE
Add Bash portscanner without dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Name|Description
 [machinedeployment-patch.gce.sh](helper/machinedeployment-patch.gce.sh) | Scripts patches some specification of an Cluster API `MachineDeployment` object.
 [set-build-tags-to-image.sh](helper/set-build-tags-to-image.sh) | Set dedicated build tags to the [Kubermatic Charts](https://github.com/kubermatic/kubermatic/tree/master/charts)
 [untaint_master.sh](helper/untaint_master.sh) | untaints all master nodes, to be able to schedule workload
-
+[bash-port-scanner.sh](helper/linux-port-scan-without-dependencies/scan.sh) | A Bash bases Port-Scanner which is able to scan ports without any dependencies or tools like nmap
 ## Knowledge Base
 Helpful how-tos and detailed documentation:
 

--- a/helper/linux-port-scan-without-dependencies/scan.sh
+++ b/helper/linux-port-scan-without-dependencies/scan.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# A script to scan ports on remote hosts without any tools like nmap
+#
+
+subnet=192.168.178
+
+for ip in {1..254};
+do for port in {22,80,443,3306,3389};
+        do (echo >/dev/tcp/$subnet.$ip/$port) >& /dev/null \
+	&& echo "$subnet.$ip:$port is open"
+       done;
+done


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a Bash Port-Scanner which is running without any dependencies or tools like nmap
